### PR TITLE
Fix build w/o Sort Transform (disabled by default).

### DIFF
--- a/libbsc/libbsc/libbsc.cpp
+++ b/libbsc/libbsc/libbsc.cpp
@@ -66,7 +66,12 @@ int bsc_init(int features)
 
     if (result == LIBBSC_NO_ERROR) result = bsc_platform_init(features);
     if (result == LIBBSC_NO_ERROR) result = bsc_qlfc_init(features);
+
+#ifdef LIBBSC_SORT_TRANSFORM_SUPPORT
+
     if (result == LIBBSC_NO_ERROR) result = bsc_st_init(features);
+
+#endif
 
     return result;
 }


### PR DESCRIPTION
Hi, I noticed build failure when LIBBSC_SORT_TRANSFORM_SUPPORT is turned off. It is off default, so I'm a bit surprised you haven't noticed that yourself (it was possibly a quick change before releasing, I suppose). Here is the simple fix.
- libbsc/libbsc/libbsc.cpp: Add ST #ifdef around bsc_st_init().

Thanks for another nice project.
