### PR TITLE
lzp: use memcpy instead of a loop for copying memory

### DIFF
--- a/libbsc/lzp/lzp.cpp
+++ b/libbsc/lzp/lzp.cpp
@@ -179,21 +179,9 @@ int bsc_lzp_decode_block(const unsigned char * input, const unsigned char * inpu
                     const unsigned char * reference = outputStart + value;
                           unsigned char * outputEnd = output + len;
 
-                    if (output - reference < 4)
-                    {
-                        int offset[4] = {0, 3, 2, 3};
+                    while (output < outputEnd) *output++ = *reference++;
 
-                        *output++ = *reference++;
-                        *output++ = *reference++;
-                        *output++ = *reference++;
-                        *output++ = *reference++;
-
-                        reference -= offset[output - reference];
-                    }
-
-                    while (output < outputEnd) { *(unsigned int *)output = *(unsigned int*)reference; output += 4; reference += 4; }
-
-                    output = outputEnd; context = output[-1] | (output[-2] << 8) | (output[-3] << 16) | (output[-4] << 24);
+                    context = output[-1] | (output[-2] << 8) | (output[-3] << 16) | (output[-4] << 24);
                 }
                 else
                 {


### PR DESCRIPTION
The loop would always copy sizeof(unsigned int) bytes at a time which could result in memory outside of the provided buffers being accessed which could, in turn, cause a crash.

In my case, I decompress to a memory mapped file which is exactly the size of the uncompressed data, and this issue triggers a general protection fault:

```
==15802== Process terminating with default action of signal 11 (SIGSEGV)
==15802==  General Protection Fault
==15802==    at 0x5C3D692: bsc_lzp_decode_block(unsigned char const*, unsigned char const*, unsigned char*, int, int) (lzp.cpp:194)
==15802==    by 0x5C3CF92: bsc_decompress (libbsc.cpp:611)
==15802==    by 0x5C2304C: squash_bsc_decompress_buffer (squash-bsc.c:252)
==15802==    by 0x4E39ABF: squash_codec_decompress_with_options (codec.c:613)
==15802==    by 0x4E3A3C2: squash_codec_process_file_with_options (codec.c:932)
==15802==    by 0x4E3A7BC: squash_codec_decompress_file_with_options (codec.c:1067)
==15802==    by 0x401A3F: benchmark_codec_with_options (in /home/nemequ/local/src/squash-benchmark/benchmark)
==15802==    by 0x401FD1: benchmark_codec (in /home/nemequ/local/src/squash-benchmark/benchmark)
==15802==    by 0x4022DC: main (in /home/nemequ/local/src/squash-benchmark/benchmark)
```