### PR TITLE
Do not depend on unaligned stores/loads, which are undefined behavior

### DIFF
--- a/libbsc/coder/coder.cpp
+++ b/libbsc/coder/coder.cpp
@@ -139,8 +139,13 @@ int bsc_coder_compress_serial(const unsigned char * input, unsigned char * outpu
             result = inputSize; memcpy(output + outputPtr, input + inputStart, inputSize);
         }
 
+#if defined(BSC_ALLOW_UNALIGNED)
         *(int *)(output + 1 + 8 * blockId + 0) = inputSize;
         *(int *)(output + 1 + 8 * blockId + 4) = result;
+#else
+        memcpy(output + 1 + 8 * blockId + 0, &inputSize, sizeof(int));
+        memcpy(output + 1 + 8 * blockId + 4, &result, sizeof(int));
+#endif
 
         outputPtr += result;
     }

--- a/libbsc/coder/common/rangecoder.h
+++ b/libbsc/coder/common/rangecoder.h
@@ -62,12 +62,22 @@ private:
 
     INLINE void OutputShort(unsigned short s)
     {
+#if defined(BSC_ALLOW_UNALIGNED)
         *ari_output++ = s;
+#else
+        memcpy(ari_output++, &s, sizeof(unsigned short));
+#endif
     };
 
     INLINE unsigned short InputShort()
     {
+#if defined(BSC_ALLOW_UNALIGNED)
         return *ari_input++;
+#else
+        unsigned short ret;
+        memcpy(&ret, ari_input++, sizeof(unsigned short));
+        return ret;
+#endif
     };
 
     INLINE void ShiftLow()


### PR DESCRIPTION
Even on x86, unaligned stores/loads are dangerous.  While most instructions support them, many vector instructions don't, which means that things like new compiler optimizations can (and do) cause code to start crashing with no warning.

I didn't bother benchmarking this since I consider it a bug, but Yann Collet [did some research a few months ago](http://fastcompression.blogspot.fr/2015/08/accessing-unaligned-memory.html).  Note that GCC 6 is supposed to fix [the issue with memcpy on ARM](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=67366).
