### PR TITLE
remove value range from docs parameter identifier

### DIFF
--- a/libbsc/libbsc.h
+++ b/libbsc/libbsc.h
@@ -109,10 +109,10 @@ extern "C" {
     * @param input                              - the input memory block of n bytes.
     * @param output                             - the output memory block of n + LIBBSC_HEADER_SIZE bytes.
     * @param n                                  - the length of the input memory block.
-    * @param lzpHashSize[0, 10..28]             - the hash table size if LZP enabled, 0 otherwise.
-    * @param lzpMinLen[0, 4..255]               - the minimum match length if LZP enabled, 0 otherwise.
-    * @param blockSorter[ST3..ST8, BWT]         - the block sorting algorithm.
-    * @param coder[MTF or QLFC]                 - the entropy coding algorithm.
+    * @param lzpHashSize                        - the hash table size if LZP enabled, 0 otherwise. Must be in range [0, 10..28].
+    * @param lzpMinLen                          - the minimum match length if LZP enabled, 0 otherwise. Must be in range [0, 4..255].
+    * @param blockSorter                        - the block sorting algorithm. Must be in range [ST3..ST8, BWT].
+    * @param coder                              - the entropy coding algorithm. Must be in range [MTF or QLFC].
     * @param features                           - the set of additional features.
     * @return the length of compressed memory block if no error occurred, error code otherwise.
     */
@@ -132,8 +132,8 @@ extern "C" {
     * Determinate the sizes of input and output memory blocks for bsc_decompress function.
     * @param blockHeader                        - the header of input(compressed) memory block of headerSize bytes.
     * @param headerSize                         - the length of header, should be at least LIBBSC_HEADER_SIZE bytes.
-    * @param pBlockSize[out]                    - the length of the input memory block for bsc_decompress function.
-    * @param pDataSize[out]                     - the length of the output memory block for bsc_decompress function.
+    * @param pBlockSize                         - the length of the input memory block for bsc_decompress function.
+    * @param pDataSize                          - the length of the output memory block for bsc_decompress function.
     * @param features                           - the set of additional features.
     * @return LIBBSC_NO_ERROR if no error occurred, error code otherwise.
     */


### PR DESCRIPTION
When compiling with clang version 16 and option `-Wdocumentation` I get an error `warning: parameter 'lzpHashSize[0,' not found in the function declaration [-Wdocumentation]`. The problem is that in source code documentation line `@param lzpHashSize[0, 10..28]` the identifier is thought to be `lzpHashSize[0` instead of `lzpHashSize`. 

I fix it by specifying parameter value range later in it's description instead of doing it inside identifier. 