### PR TITLE
Change unaligned access to memcpy/memcmp

### DIFF
--- a/libbsc/coder/coder.cpp
+++ b/libbsc/coder/coder.cpp
@@ -339,6 +339,7 @@ int bsc_coder_decompress(const unsigned char * input, unsigned char * output, in
     {
         for (int blockId = 0; blockId < nBlocks; ++blockId)
         {
+#if defined(LIBBSC_ALLOW_UNALIGNED_ACCESS)
             int inputPtr  = 0; for (int p = 0; p < blockId; ++p) inputPtr  += *(int *)(input + 1 + 8 * p + 4);
             int outputPtr = 0; for (int p = 0; p < blockId; ++p) outputPtr += *(int *)(input + 1 + 8 * p + 0);
 
@@ -346,7 +347,22 @@ int bsc_coder_decompress(const unsigned char * input, unsigned char * output, in
 
             int inputSize  = *(int *)(input + 1 + 8 * blockId + 4);
             int outputSize = *(int *)(input + 1 + 8 * blockId + 0);
+#else
+            int inputPtr = 0, outputPtr = 0;
+            for (int p = 0; p < blockId; ++p) {
+              int tmp;
+              memcpy(&tmp, input + 1 + 8 * p + 4, sizeof(int));
+              inputPtr += tmp;
+              memcpy(&tmp, input + 1 + 8 * p + 0, sizeof(int));
+              outputPtr += tmp;
+            }
 
+            inputPtr += 1 + 8 * nBlocks;
+
+            int inputSize, outputSize;
+            memcpy(&inputSize, input + 1 + 8 * blockId + 4, sizeof(int));
+            memcpy(&outputSize, input + 1 + 8 * blockId + 0, sizeof(int));
+#endif
             if (inputSize != outputSize)
             {
                 decompressionResult[blockId] = bsc_coder_decode_block(input + inputPtr, output + outputPtr, coder);

--- a/libbsc/coder/coder.cpp
+++ b/libbsc/coder/coder.cpp
@@ -193,8 +193,13 @@ int bsc_coder_compress_parallel(const unsigned char * input, unsigned char * out
                     compressionResult[blockId] = bsc_coder_encode_block(input + blockStart, buffer + blockStart, blockSize, blockSize, coder);
                     if (compressionResult[blockId] < LIBBSC_NO_ERROR) compressionResult[blockId] = blockSize;
 
+#if defined(LIBBSC_ALLOW_UNALIGNED_ACCESS)
                     *(int *)(output + 1 + 8 * blockId + 0) = blockSize;
                     *(int *)(output + 1 + 8 * blockId + 4) = compressionResult[blockId];
+#else
+                    memcpy(output + 1 + 8 * blockId + 0, &blockSize, sizeof(int));
+                    memcpy(output + 1 + 8 * blockId + 4, compressionResult + blockId, sizeof(int));
+#endif
                 }
 
                 #pragma omp single
@@ -292,6 +297,7 @@ int bsc_coder_decompress(const unsigned char * input, unsigned char * output, in
         #pragma omp parallel for schedule(dynamic)
         for (int blockId = 0; blockId < nBlocks; ++blockId)
         {
+#if defined(LIBBSC_ALLOW_UNALIGNED_ACCESS)
             int inputPtr  = 0; for (int p = 0; p < blockId; ++p) inputPtr  += *(int *)(input + 1 + 8 * p + 4);
             int outputPtr = 0; for (int p = 0; p < blockId; ++p) outputPtr += *(int *)(input + 1 + 8 * p + 0);
 
@@ -299,6 +305,22 @@ int bsc_coder_decompress(const unsigned char * input, unsigned char * output, in
 
             int inputSize  = *(int *)(input + 1 + 8 * blockId + 4);
             int outputSize = *(int *)(input + 1 + 8 * blockId + 0);
+#else
+            int inputPtr = 0, outputPtr = 0;
+            for (int p = 0; p < blockId; ++p) {
+              int tmp;
+              memcpy(&tmp, input + 1 + 8 * p + 4, sizeof(int));
+              inputPtr += tmp;
+              memcpy(&tmp, input + 1 + 8 * p + 0, sizeof(int));
+              outputPtr += tmp;
+            }
+
+            inputPtr += 1 + 8 * nBlocks;
+
+            int inputSize, outputSize;
+            memcpy(&inputSize, input + 1 + 8 * blockId + 4, sizeof(int));
+            memcpy(&outputSize, input + 1 + 8 * blockId + 0, sizeof(int));
+#endif
 
             if (inputSize != outputSize)
             {

--- a/libbsc/lzp/lzp.cpp
+++ b/libbsc/lzp/lzp.cpp
@@ -883,6 +883,7 @@ int bsc_lzp_decompress(const unsigned char * input, unsigned char * output, int 
     {
         for (int blockId = 0; blockId < nBlocks; ++blockId)
         {
+#if defined(LIBBSC_ALLOW_UNALIGNED_ACCESS)
             int inputPtr = 0;  for (int p = 0; p < blockId; ++p) inputPtr  += *(int *)(input + 1 + 8 * p + 4);
             int outputPtr = 0; for (int p = 0; p < blockId; ++p) outputPtr += *(int *)(input + 1 + 8 * p + 0);
 
@@ -890,6 +891,22 @@ int bsc_lzp_decompress(const unsigned char * input, unsigned char * output, int 
 
             int inputSize  = *(int *)(input + 1 + 8 * blockId + 4);
             int outputSize = *(int *)(input + 1 + 8 * blockId + 0);
+#else
+            int inputPtr = 0, outputPtr = 0;
+            for (int p = 0; p < blockId; ++p) {
+              int tmp;
+              memcpy(&tmp, input + 1 + 8 * p + 4, sizeof(int));
+              inputPtr += tmp;
+              memcpy(&tmp, input + 1 + 8 * p + 0, sizeof(int));
+              outputPtr += tmp;
+            }
+
+            inputPtr += 1 + 8 * nBlocks;
+
+            int inputSize, outputSize;
+            memcpy(&inputSize, input + 1 + 8 * blockId + 4, sizeof(int));
+            memcpy(&outputSize, input + 1 + 8 * blockId + 0, sizeof(int));
+#endif
 
             if (inputSize != outputSize)
             {

--- a/libbsc/lzp/lzp.cpp
+++ b/libbsc/lzp/lzp.cpp
@@ -465,7 +465,11 @@ int bsc_lzp_encode_generic(const unsigned char * RESTRICT input, const unsigned 
                 if ((memcmp(input + minLen - 4, reference + minLen - 4, sizeof(unsigned int)) == 0) && (memcmp(input, reference, sizeof(unsigned int)) == 0))
 #endif
                 {
+#if defined(LIBBSC_ALLOW_UNALIGNED_ACCESS)
                     if ((heuristic > input) && (*(unsigned int *)heuristic != *(unsigned int *)(reference + (heuristic - input))))
+#else
+                    if ((heuristic > input) && (memcmp(heuristic, reference + (heuristic - input), sizeof(unsigned int)) != 0))
+#endif
                     {
                         goto LIBBSC_LZP_MATCH_NOT_FOUND;
                     }
@@ -473,7 +477,11 @@ int bsc_lzp_encode_generic(const unsigned char * RESTRICT input, const unsigned 
                     int len = 4;
                     for (; input + len < inputMinLenEnd; len += sizeof(unsigned int))
                     {
+#if defined(LIBBSC_ALLOW_UNALIGNED_ACCESS)
                         if (*(unsigned int *)(input + len) != *(unsigned int *)(reference + len)) break;
+#else
+                        if (memcmp(input + len, reference + len, sizeof(unsigned int)) != 0) break;
+#endif
                     }
 
                     if (len < minLen)
@@ -747,8 +755,13 @@ int bsc_lzp_compress_parallel(const unsigned char * input, unsigned char * outpu
                     compressionResult[blockId] = bsc_lzp_encode_block(input + blockStart, input + blockStart + blockSize, buffer + blockStart, buffer + blockStart + blockSize, hashSize, minLen);
                     if (compressionResult[blockId] < LIBBSC_NO_ERROR) compressionResult[blockId] = blockSize;
 
+#if defined(LIBBSC_ALLOW_UNALIGNED_ACCESS)
                     *(int *)(output + 1 + 8 * blockId + 0) = blockSize;
                     *(int *)(output + 1 + 8 * blockId + 4) = compressionResult[blockId];
+#else
+                    memcpy(output + 1 + 8 * blockId + 0, &blockSize, sizeof(int));
+                    memcpy(output + 1 + 8 * blockId + 4, compressionResult + blockId, sizeof(int));
+#endif
                 }
 
                 #pragma omp single
@@ -828,6 +841,7 @@ int bsc_lzp_decompress(const unsigned char * input, unsigned char * output, int 
         #pragma omp parallel for schedule(dynamic)
         for (int blockId = 0; blockId < nBlocks; ++blockId)
         {
+#if defined(LIBBSC_ALLOW_UNALIGNED_ACCESS)
             int inputPtr = 0;  for (int p = 0; p < blockId; ++p) inputPtr  += *(int *)(input + 1 + 8 * p + 4);
             int outputPtr = 0; for (int p = 0; p < blockId; ++p) outputPtr += *(int *)(input + 1 + 8 * p + 0);
 
@@ -835,6 +849,22 @@ int bsc_lzp_decompress(const unsigned char * input, unsigned char * output, int 
 
             int inputSize  = *(int *)(input + 1 + 8 * blockId + 4);
             int outputSize = *(int *)(input + 1 + 8 * blockId + 0);
+#else
+            int inputPtr = 0, outputPtr = 0;
+            for (int p = 0; p < blockId; ++p) {
+              int tmp;
+              memcpy(&tmp, input + 1 + 8 * p + 4, sizeof(int));
+              inputPtr += tmp;
+              memcpy(&tmp, input + 1 + 8 * p + 0, sizeof(int));
+              outputPtr += tmp;
+            }
+
+            inputPtr += 1 + 8 * nBlocks;
+
+            int inputSize, outputSize;
+            memcpy(&inputSize, input + 1 + 8 * blockId + 4, sizeof(int));
+            memcpy(&outputSize, input + 1 + 8 * blockId + 0, sizeof(int));
+#endif
 
             if (inputSize != outputSize)
             {


### PR DESCRIPTION
With the help of `-fsanitize=undefined`, several more cases of UB were discovered and surrounded with the macro, similar to how it was already done here: https://github.com/IlyaGrebnov/libbsc/pull/5

P.S. One suggestion:
add several small utilities - either inline functions or templates - for working with raw memory, perhaps in `libbsc/utils.h`. In it's body, such a function will cast pointers or call memcpy/memcmp, depending on `LIBBSC_ALLOW_UNALIGNED_ACCESS` macro. 

Using these functions across the codebase would make it a bit easier to read and maintain, as now this macro is encountered quite often. There also shouldn't be any performance costs (compared to the macro) due to inlining.

P.P.S. I volunteer to implement:)