### PR TITLE
Add libbsc version API

### DIFF
--- a/README
+++ b/README
@@ -73,8 +73,25 @@ http://msdn.microsoft.com/en-us/windows/hardware/gg487368.aspx#E2
 
 Installation
 ------------
-1. Make sure you have typical build tools, make, cmake, a compiler, etc.
+1. Make sure you have typical build tools: cmake, make or another build tool,
+   and C/C++ compilers.
 2. Clone this repo locally and cd to it.
-3. Run `cmake` or `cmake -DBSC_BUILD_SHARED_LIB=ON` if you also want a shared library.
-4. Run `make`.
-5. Run `sudo make install`.
+3. Configure and build the project:
+
+       cmake -S . -B build
+       cmake --build build
+
+   To build libbsc as a shared library, configure with:
+
+       cmake -S . -B build -DBSC_BUILD_SHARED_LIB=ON
+       cmake --build build
+
+   If you do not want CUDA support, add `-DBSC_ENABLE_CUDA=OFF`.
+
+4. Optionally run the tests:
+
+       ctest --test-dir build --output-on-failure
+
+5. Install the library and command-line tool:
+
+       sudo cmake --install build

--- a/libbsc/libbsc.h
+++ b/libbsc/libbsc.h
@@ -104,6 +104,12 @@ extern "C" {
 #endif
 
     /**
+    * Return the libbsc version string.
+    * @return version string in MAJOR.MINOR.PATCH format.
+    */
+    LIBBSC_API const char * bsc_version(void);
+
+    /**
     * You should call this function (or @ref bsc_init_full) before you call any of the other functions in libbsc.
     * @param features - the set of additional features.
     * @return LIBBSC_NO_ERROR if no error occurred, error code otherwise.

--- a/libbsc/libbsc/libbsc.cpp
+++ b/libbsc/libbsc/libbsc.cpp
@@ -43,6 +43,11 @@ See also the bsc and libbsc web site:
 #include "../coder/coder.h"
 #include "../st/st.h"
 
+const char * bsc_version(void)
+{
+    return LIBBSC_VERSION_STRING;
+}
+
 int bsc_init_full(int features, void* (* malloc)(size_t size), void* (* zero_malloc)(size_t size), void (* free)(void* address))
 {
     int result = LIBBSC_NO_ERROR;


### PR DESCRIPTION
I realized that my Ruby library, which uses FFI, had no good way to tell which version of libbsc it was using under the hood. So, I've added a simple version function here that I and anyone else using your library can hook into.

While I was here I updated the build instructions because I realized they were too simple and not entirely accurate anyway.